### PR TITLE
Sugar for the development experience.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,16 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "file", source: "dot_lpdev_cmds.sh", destination: "$HOME/.lpdev_cmds.sh"
   config.vm.provision "shell", inline: "if ! grep -q lpdev_cmds.sh /home/vagrant/.bashrc; then echo 'source $HOME/.lpdev_cmds.sh' >> /home/vagrant/.bashrc; fi"
+  config.vm.provision "shell", privileged: false, inline: <<~SCREENRC
+    cat <<-SHELL_SCREENRC > $HOME/.screenrc
+    	# An alternative hardstatus to display a bar at the bottom listing the
+    	# windownames and highlighting the current windowname in blue. (This is only
+    	# enabled if there is no hardstatus setting for your terminal)
+    	hardstatus on
+    	hardstatus alwayslastline
+    	hardstatus string "%{.bW}%-w%{.rW}%n %t%{-}%+w %=%{..G} %H %{..Y} %m/%d %C%a "
+    SHELL_SCREENRC
+  SCREENRC
 
   config.vm.provider "virtualbox" do |vb|
     # Customize the number of CPUs and amount of memory on the VM:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,6 +61,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "file", source: "dot_lpdev_cmds.sh", destination: "$HOME/.lpdev_cmds.sh"
   config.vm.provision "shell", inline: "if ! grep -q lpdev_cmds.sh /home/vagrant/.bashrc; then echo 'source $HOME/.lpdev_cmds.sh' >> /home/vagrant/.bashrc; fi"
+  config.vm.provision "shell", privileged: false, inline: "source $HOME/.lpdev_cmds.sh && __lpdev_node_update --no-verbose"
   config.vm.provision "shell", privileged: false, inline: <<~SCREENRC
     cat <<-SHELL_SCREENRC > $HOME/.screenrc
     	# An alternative hardstatus to display a bar at the bottom listing the

--- a/dot_lpdev_cmds.sh
+++ b/dot_lpdev_cmds.sh
@@ -441,6 +441,8 @@ function __lpdev_node_reset {
 
 function __lpdev_node_update {
 
+  wget_args=$1
+
   URL=$(curl -s https://api.github.com/repos/livepeer/go-livepeer/releases |jq -r ".[0].assets[].browser_download_url" | grep linux)
 
   if [ -z $URL ]
@@ -450,7 +452,7 @@ function __lpdev_node_update {
   fi
 
   cd $HOME
-  wget $URL
+  wget $wget_args $URL
   tar -xf livepeer_linux.tar
   rm livepeer_linux.tar
   echo "Don't forget to restart any running nodes to use the latest release"


### PR DESCRIPTION
#### Provision screenrc.

Note this intentionally mixes spaces and tabs to preserve some
semblance of formatting in the editor. We introduce tabs within
the inner heredoc in order to satisfy bash rules on suppressing
leading indentation in the script's output.

#### Fetch latest livepeer release when provisioning.