### PR TITLE
mount go-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,9 @@ Transcoder node is running: true (21182)
 --
 
 What would you like to do?
-1) Display status                      5) Start & set up transcoder node
-2) Set up & start Geth local network   6) Destroy current environmentonment
-3) Deploy/overwrite protocol contracts 7) Exit
-4) Start & set up broadcaster node
+1) Display status			  4) Start & set up broadcaster node	   7) Update livepeer and cli		   10) Destroy current environment
+2) Set up & start Geth local network	  5) Start & set up transcoder node	   8) Install FFmpeg			   11) Exit
+3) Deploy/overwrite protocol contracts	  6) Start & set up verifier		   9) Rebuild FFmpeg
 ```
 
 _The Current Status values above are specific to your environment. Yours
@@ -144,7 +143,8 @@ host-machine $ vagrant provision
 
 ### ~/go
 This is the $GOROOT for this virtual machine. This doesn't exist until you
-install software using `go get [software]`.
+install software using `go get [software]`.  _Changes to this directory are 
+made to the host machine and vice versa in `$LPSRC/go_src`._
 
 ### ~/livepeer_linux
 This directory is where the latest official release of the Livepeer node

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,7 +58,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.synced_folder project_src_dirs, "/home/vagrant/src", create: true
-  config.vm.synced_folder File.join(project_src_dirs,"go_src"), "/home/vagrant/go", create: true
+  config.vm.synced_folder File.join(project_src_dirs,"go"), "/home/vagrant/go", create: true
 
   config.vm.provision "shell", inline: "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
   config.vm.provision "shell", inline: "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\""

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -58,6 +58,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.synced_folder project_src_dirs, "/home/vagrant/src", create: true
+  config.vm.synced_folder File.join(project_src_dirs,"go_src"), "/home/vagrant/go", create: true
 
   config.vm.provision "shell", inline: "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
   config.vm.provision "shell", inline: "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\""


### PR DESCRIPTION
For now, let's mount go-path to the same data directory as everything else.  This way we can still develop using our native IDE on the base box, and see the code changes reflected in the VM.