### PR TITLE
Miscellaneous fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,6 +33,8 @@ default_nodes = ENV["NODES"] || 5
 rtmp_port = 1935
 api_port = 8935
 ipfs_port = 4001
+js_port = 3000
+rpc_port = 8545
 
 # Get current user pid and gid
 uid = Etc.getpwnam(ENV["USER"]).uid
@@ -53,6 +55,8 @@ Vagrant.configure("2") do |config|
     end
 
     config.vm.network "forwarded_port", guest: ipfs_port, host: ipfs_port
+    config.vm.network "forwarded_port", guest: js_port, host: js_port
+    config.vm.network "forwarded_port", guest: rpc_port, host: rpc_port
   else
     config.vm.network "public_network"
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -61,9 +61,11 @@ Vagrant.configure("2") do |config|
   config.vm.synced_folder File.join(project_src_dirs,"go"), "/home/vagrant/go", create: true
 
   config.vm.provision "shell", inline: "curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -"
+  config.vm.provision "shell", inline: "curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -"
   config.vm.provision "shell", inline: "sudo add-apt-repository \"deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable\""
+  config.vm.provision "shell", inline: "echo 'deb https://dl.yarnpkg.com/debian/ stable main' | sudo tee /etc/apt/sources.list.d/yarn.list"
   config.vm.provision "shell", inline: "sudo apt-get update"
-  config.vm.provision "shell", inline: "sudo apt-get install -y bindfs jq unzip docker-ce autotools-dev autoconf"
+  config.vm.provision "shell", inline: "sudo apt-get install -y bindfs jq unzip docker-ce autotools-dev autoconf yarn"
 
   config.vm.provision "file", source: "dot_lpdev_cmds.sh", destination: "$HOME/.lpdev_cmds.sh"
   config.vm.provision "file", source: "build_src_deps.sh", destination: "$HOME/.build_src_deps.sh"

--- a/dot_lpdev_cmds.sh
+++ b/dot_lpdev_cmds.sh
@@ -523,7 +523,7 @@ function __lpdev_node_broadcaster {
   if ! $broadcasterRunning && [ -n $broadcasterGeth ]
   then
     echo "Running LivePeer broadcast node with the following command:
-      $binDir -bootnode \\
+      $binDir -bootIDs "" -bootAddrs "" \\
               -controllerAddr $controllerAddress \\
               -datadir $nodeDataDir \\
               -ethAcctAddr $broadcasterGeth \\
@@ -534,7 +534,7 @@ function __lpdev_node_broadcaster {
               -rtmp $broadcasterRtmpPort \\
               -http $broadcasterApiPort"
 
-    nohup $binDir -bootnode -controllerAddr $controllerAddress -datadir $nodeDataDir \
+    nohup $binDir -bootIDs "" -bootAddrs "" -controllerAddr $controllerAddress -datadir $nodeDataDir \
       -ethAcctAddr $broadcasterGeth -ethIpcPath $gethIPC -ethKeystorePath $ethKeystorePath -ethPassword "pass" \
       -monitor=false -rtmp $broadcasterRtmpPort \
       -http $broadcasterApiPort &>> $nodeDataDir/broadcaster.log &


### PR DESCRIPTION
Install yarn during provisioning. Bridge JS (Node) and geth RPC ports.

Both commits are needed for LivepeerJS. Actually installing LPJS isn't implemented in the dotfile yet but this should be all the VM-level configuration that's needed.

Set forceOnchain option on broadcaster.  Depends on https://github.com/livepeer/go-livepeer/pull/374