### PR TITLE
create node_modules dir inside protocol dir

### DIFF
--- a/dot_lpdev_cmds.sh
+++ b/dot_lpdev_cmds.sh
@@ -323,6 +323,7 @@ function __lpdev_protocol_init {
   if ! mountpoint -q $srcDir/protocol/node_modules
   then
     echo "Mounting local vm node_modules"
+    mkdir -p $srcDir/protocol/node_modules
     bindfs -n -o nonempty $HOME/.protocol_node_modules $srcDir/protocol/node_modules
   fi
 


### PR DESCRIPTION
on fresh protocol checkout binding gives error because `node_modules` dir doesn't exists