### PR TITLE
Vagrant: added `go-livepeer` to PATH

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,6 +80,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "install_src_deps.sh", destination: "$HOME/.install_src_deps.sh"
   config.vm.provision "shell", inline: "if ! grep -q lpdev_cmds.sh /home/vagrant/.bashrc; then echo 'source $HOME/.lpdev_cmds.sh' >> /home/vagrant/.bashrc; fi"
   config.vm.provision "shell", inline: "if ! grep -q LD_LIBRARY_PATH /home/vagrant/.bashrc; then echo 'export LD_LIBRARY_PATH=/usr/local/lib' >> /home/vagrant/.bashrc; fi"
+  config.vm.provision "shell", inline: "if ! grep -q go-livepeer /home/vagrant/.profile; then echo 'PATH=$HOME/go/src/github.com/livepeer/go-livepeer:$PATH' >> /home/vagrant/.profile; fi"
   config.vm.provision "shell", privileged: false, inline: "source $HOME/.lpdev_cmds.sh && __lpdev_node_update --no-verbose"
   config.vm.provision "shell", privileged: false, inline: <<~SCREENRC
     cat <<-SHELL_SCREENRC > $HOME/.screenrc


### PR DESCRIPTION
To optimize the development flow of making a change, compiling and then
re-running `livepeer`. Before this change we had to move the new binary
into a different folder that was part of PATH, e.g.
`/home/vagrant/go/bin/`.