### PR TITLE
install go-livepeer from source

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -80,8 +80,10 @@ Vagrant.configure("2") do |config|
   config.vm.provision "file", source: "install_src_deps.sh", destination: "$HOME/.install_src_deps.sh"
   config.vm.provision "shell", inline: "if ! grep -q lpdev_cmds.sh /home/vagrant/.bashrc; then echo 'source $HOME/.lpdev_cmds.sh' >> /home/vagrant/.bashrc; fi"
   config.vm.provision "shell", inline: "if ! grep -q LD_LIBRARY_PATH /home/vagrant/.bashrc; then echo 'export LD_LIBRARY_PATH=/usr/local/lib' >> /home/vagrant/.bashrc; fi"
+  config.vm.provision "shell", inline: "if ! grep -q GOPATH /home/vagrant/.profile; then echo 'GOPATH=$HOME/go' >> /home/vagrant/.profile; fi"
   config.vm.provision "shell", inline: "if ! grep -q go-livepeer /home/vagrant/.profile; then echo 'PATH=$HOME/go/src/github.com/livepeer/go-livepeer:$PATH' >> /home/vagrant/.profile; fi"
-  config.vm.provision "shell", privileged: false, inline: "source $HOME/.lpdev_cmds.sh && __lpdev_node_update --no-verbose"
+  config.vm.provision "shell", privileged: false, inline: "command -v ffmpeg >/dev/null 2>&1 || $HOME/.install_src_deps.sh"
+  config.vm.provision "shell", privileged: false, inline: "source /home/vagrant/.profile && source $HOME/.lpdev_cmds.sh && __lpdev_node_update --no-verbose"
   config.vm.provision "shell", privileged: false, inline: <<~SCREENRC
     cat <<-SHELL_SCREENRC > $HOME/.screenrc
     	# An alternative hardstatus to display a bar at the bottom listing the

--- a/dot_lpdev_cmds.sh
+++ b/dot_lpdev_cmds.sh
@@ -570,23 +570,20 @@ function __lpdev_node_reset {
 }
 
 function __lpdev_node_update {
-
-  wget_args=$1
-
-  URL=$(curl -s https://api.github.com/repos/livepeer/go-livepeer/releases |jq -r ".[0].assets[].browser_download_url" | grep linux)
-
-  if [ -z $URL ]
+  if [ -d $GOPATH/src/github.com/livepeer/go-livepeer ]
   then
-    echo "Couldn't find the latest Linux release ($URL return instead)"
-    return 1
+    echo "go-livepeer src directory exists. Installing using local version"
+    OPWD=$PWD
+    cd $GOPATH/src/github.com/livepeer/go-livepeer
+    go install ./cmd/...
+    cd $OPWD
+  else
+    goGetCmd="go get github.com/livepeer/go-livepeer/cmd/..."
+    echo "$goGetCmd: Downloading and installing go-livepeer packages"
+    eval $goGetCmd
   fi
 
-  cd $HOME
-  wget $wget_args $URL
-  tar -xzf livepeer_linux.tar.gz
-  rm livepeer_linux.tar.gz
   echo "Don't forget to restart any running nodes to use the latest release"
-
 }
 
 function __lpdev_node_broadcaster {


### PR DESCRIPTION
Install go-livepeer from source
- If the source directory already exists locally, use `go install` to build (to incorporate any recent changes)
- If the source directory does not exist locally, use `go get` to download and install the packages

Fixes #38 and #36